### PR TITLE
Dulwich

### DIFF
--- a/performance/benchmarks/__init__.py
+++ b/performance/benchmarks/__init__.py
@@ -342,6 +342,12 @@ def BM_pidigits(python, options):
     return run_perf_script(python, options, bm_path)
 
 
+@VersionRange()
+def BM_dulwich_log(python, options):
+    bm_path = Relative("bm_dulwich_log.py")
+    return run_perf_script(python, options, bm_path)
+
+
 ### End benchmarks, begin main entry point support.
 
 def _FindAllBenchmarks(namespace):

--- a/performance/benchmarks/bm_dulwich_log.py
+++ b/performance/benchmarks/bm_dulwich_log.py
@@ -1,0 +1,29 @@
+import os
+
+import perf.text_runner
+from six.moves import xrange
+
+import dulwich.repo
+
+
+def test_dulwich(loops, repo_path):
+    repo = dulwich.repo.Repo(repo_path)
+    head = repo.head()
+    range_it = xrange(loops)
+    t0 = perf.perf_counter()
+
+    for _ in range_it:
+        # iterate on all changes on the Git repository
+        for entry in repo.get_walker(head):
+            pass
+
+    return perf.perf_counter() - t0
+
+
+if __name__ == "__main__":
+    runner = perf.text_runner.TextRunner(name='dulwich_log')
+    runner.metadata['description'] = ("Dulwich benchmark: "
+                                      "iterate on all Git commits")
+
+    repo_path = os.path.join(os.path.dirname(__file__), 'data', 'asyncio.git')
+    runner.bench_sample_func(test_dulwich, repo_path)

--- a/performance/benchmarks/bm_go.py
+++ b/performance/benchmarks/bm_go.py
@@ -449,6 +449,7 @@ def main(loops):
 
     return perf.perf_counter() - t0
 
+
 if __name__ == "__main__":
     kw = {}
     if perf.python_has_jit():

--- a/performance/requirements.txt
+++ b/performance/requirements.txt
@@ -56,6 +56,7 @@ perf==0.7.11
 Chameleon==2.24                           # chameleon
 Django==1.10.1                            # django_template
 Mako==1.0.4                               # mako
+dulwich==0.14.1                           # dulwich_log
 mercurial==3.9.1; python_version < '3.0'  # hg_startup
 html5lib==0.999999999                     # html5lib
 pathlib2==2.1.0; python_version < '3.4'   # pathlib


### PR DESCRIPTION
Benchmark coming from PyPy benchmarks: https://bitbucket.org/pypy/benchmarks/src/59290b59a24e54057d4c694fa4f47e7879a347a0/own/bm_dulwich_log.py?at=default&fileviewer=file-view-default

I propose to use https://github.com/python/asyncio Git repository (1552 commits; 2.1 MB) instead of topaz Git repository used by PyPy benchmarks (4554 commits; 17 MB).