### PR TITLE
Add python_startup_stdlibs benchmark

### DIFF
--- a/performance/benchmarks/__init__.py
+++ b/performance/benchmarks/__init__.py
@@ -244,6 +244,11 @@ def BM_python_startup_no_site(python, options):
                            extra_args=["--no-site"])
 
 
+def BM_python_startup_stdlibs(python, options):
+    return run_perf_script(python, options, "python_startup",
+                           extra_args=["--stdlibs"])
+
+
 def BM_regex_v8(python, options):
     return run_perf_script(python, options, "regex_v8")
 

--- a/performance/benchmarks/bm_python_startup.py
+++ b/performance/benchmarks/bm_python_startup.py
@@ -8,6 +8,33 @@ import perf
 from six.moves import xrange
 
 
+# common stdlibs. Many applications imports them directly, or indirectly.
+IMPORT_COMMON_STDLIBS = """\
+import abc
+import argparse
+import collections
+import copy
+import ctypes
+import datetime
+#import enum  # Python >=3.4
+import functools
+import io
+import json
+import logging
+import os
+#import pathlib  # Python >=3.4
+import re
+import socket
+import struct
+import subprocess
+import tempfile
+import threading
+import types
+#import typing  # Python >=3.5
+import urllib
+"""
+
+
 def bench_startup(loops, command):
     run = subprocess.check_call
     range_it = xrange(loops)
@@ -22,21 +49,29 @@ def bench_startup(loops, command):
 def add_cmdline_args(cmd, args):
     if args.no_site:
         cmd.append("--no-site")
+    if args.stdlibs:
+        cmd.append("--stdlibs")
 
 
 if __name__ == "__main__":
     runner = perf.Runner(samples=10, add_cmdline_args=add_cmdline_args)
     runner.argparser.add_argument("--no-site", action="store_true")
+    runner.argparser.add_argument("--stdlibs", action="store_true")
 
     runner.metadata['description'] = "Performance of the Python startup"
     args = runner.parse_args()
     name = 'python_startup'
     if args.no_site:
         name += "_no_site"
+    if args.stdlibs:
+        name += "_stdlibs"
 
     command = [sys.executable]
     if args.no_site:
         command.append("-S")
-    command.extend(("-c", "pass"))
+    if args.stdlibs:
+        command.extend(("-c", IMPORT_COMMON_STDLIBS))
+    else:
+        command.extend(("-c", "pass"))
 
     runner.bench_sample_func(name, bench_startup, command)


### PR DESCRIPTION
There are some very common stdlib modules which is not imported by site module.
They affects startup time of command line applications.

Having benchmark to import them helps we notice how stdlibs going fatter.