### PR TITLE
changes warn to warning

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,9 @@ Changelog
 Version 0.5.6
 -------------
 
+* Change ``warn`` to ``warning`` in `bm_logging.py` .In Python 3, Logger.warn()
+  calls warnings.warn(), so is slower than Logger.warning() and
+  warnings.warn() is called to log a deprecation warning.
 * Add again the ``logging_silent`` microbenchmark suite.
 * compile command: update the Git repository before getting the revision
 

--- a/performance/benchmarks/bm_logging.py
+++ b/performance/benchmarks/bm_logging.py
@@ -71,16 +71,16 @@ def bench_simple_output(loops, logger, stream):
 
     for _ in range_it:
         # repeat 10 times
-        logger.warn(m)
-        logger.warn(m)
-        logger.warn(m)
-        logger.warn(m)
-        logger.warn(m)
-        logger.warn(m)
-        logger.warn(m)
-        logger.warn(m)
-        logger.warn(m)
-        logger.warn(m)
+        logger.warning(m)
+        logger.warning(m)
+        logger.warning(m)
+        logger.warning(m)
+        logger.warning(m)
+        logger.warning(m)
+        logger.warning(m)
+        logger.warning(m)
+        logger.warning(m)
+        logger.warning(m)
 
     dt = perf.perf_counter() - t0
 
@@ -102,16 +102,16 @@ def bench_formatted_output(loops, logger, stream):
 
     for _ in range_it:
         # repeat 10 times
-        logger.warn(fmt, msg)
-        logger.warn(fmt, msg)
-        logger.warn(fmt, msg)
-        logger.warn(fmt, msg)
-        logger.warn(fmt, msg)
-        logger.warn(fmt, msg)
-        logger.warn(fmt, msg)
-        logger.warn(fmt, msg)
-        logger.warn(fmt, msg)
-        logger.warn(fmt, msg)
+        logger.warning(fmt, msg)
+        logger.warning(fmt, msg)
+        logger.warning(fmt, msg)
+        logger.warning(fmt, msg)
+        logger.warning(fmt, msg)
+        logger.warning(fmt, msg)
+        logger.warning(fmt, msg)
+        logger.warning(fmt, msg)
+        logger.warning(fmt, msg)
+        logger.warning(fmt, msg)
 
     dt = perf.perf_counter() - t0
 


### PR DESCRIPTION
I just saw that `warn` is deprecated and all tests passes with tox, thus sent a PR,but it might be inappropriate if there are other compatibility issues.