### PR TITLE
COMPAT: PyPy does not have c-accelerators for pickle

### DIFF
--- a/performance/benchmarks/bm_pickle.py
+++ b/performance/benchmarks/bm_pickle.py
@@ -17,12 +17,14 @@ from __future__ import division
 import datetime
 import random
 import sys
+import platform
 
 import perf
 import six
 from six.moves import xrange
 if six.PY3:
     long = int
+IS_PYPY = platform.python_implementation() == 'PyPy'
 
 __author__ = "collinwinter@google.com (Collin Winter)"
 
@@ -272,7 +274,7 @@ if __name__ == "__main__":
     if options.pure_python:
         name += "_pure_python"
 
-    if not options.pure_python:
+    if not (options.pure_python or IS_PYPY):
         # C accelerators are enabled by default on 3.x
         if six.PY2:
             import cPickle as pickle

--- a/performance/benchmarks/bm_pickle.py
+++ b/performance/benchmarks/bm_pickle.py
@@ -17,14 +17,13 @@ from __future__ import division
 import datetime
 import random
 import sys
-import platform
 
 import perf
 import six
 from six.moves import xrange
 if six.PY3:
     long = int
-IS_PYPY = platform.python_implementation() == 'PyPy'
+IS_PYPY = perf.python_implementation() == 'pypy'
 
 __author__ = "collinwinter@google.com (Collin Winter)"
 


### PR DESCRIPTION
change the logic to detect/use c-accelerators for pickle when using PyPy for python 3.5 (called PyPy3 by the PyPy people)