### PR TITLE
python_startup: Add --exit option

### DIFF
--- a/performance/benchmarks/bm_python_startup.py
+++ b/performance/benchmarks/bm_python_startup.py
@@ -9,21 +9,29 @@ import perf
 def add_cmdline_args(cmd, args):
     if args.no_site:
         cmd.append("--no-site")
+    if args.exit:
+        cmd.append("--exit")
 
 
 if __name__ == "__main__":
     runner = perf.Runner(values=10, add_cmdline_args=add_cmdline_args)
     runner.argparser.add_argument("--no-site", action="store_true")
+    runner.argparser.add_argument("--exit", action="store_true")
 
     runner.metadata['description'] = "Performance of the Python startup"
     args = runner.parse_args()
     name = 'python_startup'
     if args.no_site:
         name += "_no_site"
+    if args.exit:
+        name += "_exit"
 
     command = [sys.executable]
     if args.no_site:
         command.append("-S")
-    command.extend(("-c", "pass"))
+    if args.exit:
+        command.extend(("-c", "import os; os._exit(0)"))
+    else:
+        command.extend(("-c", "pass"))
 
     runner.bench_command(name, command)


### PR DESCRIPTION
Python 3 has more graceful shutdown process.
It is one of major reason why Python 3 is slower than
python_startup benchmark.

But shutdown time is not important as startup time
for applications like Vim.
And user can avoid shutdown process, while startup
overhead is unavoidable.

New `--exit` option calls `os._exit(0)` to avoid
shutdown process.  Pure startup time can be measured
by this option.