### PR TITLE
Guard against empty pip install

### DIFF
--- a/performance/venv.py
+++ b/performance/venv.py
@@ -495,14 +495,16 @@ class VirtualEnvironment(object):
         self.run_cmd(cmd)
 
         # install indirect requirements
-        cmd = pip_program + ['install']
-        cmd.extend(requirements.indirect_req)
-        self.run_cmd(cmd)
+        if requirements.indirect_req:
+            cmd = pip_program + ['install']
+            cmd.extend(requirements.indirect_req)
+            self.run_cmd(cmd)
 
         # install requirements
-        cmd = pip_program + ['install']
-        cmd.extend(requirements.req)
-        self.run_cmd(cmd)
+        if requirements.req:
+            cmd = pip_program + ['install']
+            cmd.extend(requirements.req)
+            self.run_cmd(cmd)
 
         # install optional requirements
         for req in requirements.optional:


### PR DESCRIPTION
This avoids calling `pip install` without a distribution to install (which is an error in pip 10).
Fixes #40.