### PR TITLE
Add support for native libraries that are installed but not on path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ James Abbatiello <abbeyj@gmail.com>
 Jeffrey Yasskin <jyasskin@gmail.com>
 Maciej Fijalkowski
 Reid Klecker <mk@mit.edu>
+Robert Grimm
 Skip Montanaro
 Stefan Behnel
 Thomas Wouters <thomas@python.org>

--- a/doc/benchmark.conf.sample
+++ b/doc/benchmark.conf.sample
@@ -44,7 +44,11 @@ pgo = True
 # to configure. As an exception, the prefix for openssl, if that
 # library is present here, is passed via the --with-openssl
 # option. Currently, this only works with Homebrew on macOS.
-pkg_only = openssl zlib
+# If running on macOS with Homebrew, you probably want to use:
+#     pkg_only = openssl readline sqlite3 xz zlib
+# The version of zlib shipping with macOS probably works as well,
+# as long as Apple's SDK headers are installed.
+pkg_only =
 
 # Install Python? If false, run Python from the build directory
 #

--- a/doc/benchmark.conf.sample
+++ b/doc/benchmark.conf.sample
@@ -37,6 +37,15 @@ lto = True
 # Profiled Guided Optimization (PGO)?
 pgo = True
 
+# The space-separated list of libraries that are package-only,
+# i.e., locally installed but not on header and library paths.
+# For each such library, determine the install path and add an
+# appropriate subpath to CFLAGS and LDFLAGS declarations passed
+# to configure. As an exception, the prefix for openssl, if that
+# library is present here, is passed via the --with-openssl
+# option. Currently, this only works with Homebrew on macOS.
+pkg_only = openssl zlib
+
 # Install Python? If false, run Python from the build directory
 #
 # WARNING: Running Python from the build directory introduces subtle changes


### PR DESCRIPTION
At least on macOS, installing up-to-date versions of several libraries
via a third party package manager such as Homebrew may interfere with
the rather old and tired version shipped with macOS. Consequently,
Homebrew does not add these libraries to the include and linker paths.
This change adds a configuration option to derive the correct arguments
for CPython's configure script. Adding support for other package
managers and operating systems should be trivial, since only two lines
are macOS-specific.