### PR TITLE
sudo no longer required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 dist: xenial
-sudo: false
 cache: pip
 python:
     - 2.7


### PR DESCRIPTION
The sudo keyword is now ignored.

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration